### PR TITLE
Bug 98904: [97713 - Simulador SERAp estudantes - Edição] - Campos estão trazendo as palavras do inicio dos textos sem espaço.

### DIFF
--- a/lib/features/questao/presentation/widgets/editor_html/editor_html_enhanced.dart
+++ b/lib/features/questao/presentation/widgets/editor_html/editor_html_enhanced.dart
@@ -43,7 +43,10 @@ class _EditorHtmlEnhancedState extends State<EditorHtmlEnhanced> {
         callbacks: Callbacks(
           onChangeContent: widget.onTextChanged,
           onInit: () {
-            controller.setText(widget.text);
+            // Correção de tratamento de quebras de linhas e espaços
+            var text = widget.text.replaceAll('\n', " ");
+
+            controller.setText(text);
             controller.setFullScreen();
             controller.setHint('Digite o texto');
           },


### PR DESCRIPTION
## Descrição

Fixes [AB#98904](https://dev.azure.com/amcomgov/c9b99f20-3b4d-464b-a2eb-69d1f704e9d3/_workitems/edit/98904)


## Tipo de Mudança

<!--- Coloque um `x` em todas as caixas que se aplicam: -->

- [ ] ✨ Novo recurso (alteração ininterrupta que adiciona funcionalidade)
- [X] 🛠️ Bug fix (mudança ininterrupta que corrige um problema)
- [ ] ❌ Breaking change (correção ou recurso que faria com que a funcionalidade existente fosse alterada)
- [ ] 🧹 Refatoração de código
- [ ] ✅ Alteração de configuração de compilação
- [ ] 📝 Documentação
- [ ] 🗑️ Chore (Tarefa) 
- [ ] 🔄 Sincronização de branch
