### PR TITLE
Bug 99087: [97713 - Simulador SERAp estudantes - Edição] - Campo de edição das alternativas muito pequeno não exibe todo o texto.

### DIFF
--- a/lib/features/questao/presentation/pages/questao_editar_page.dart
+++ b/lib/features/questao/presentation/pages/questao_editar_page.dart
@@ -188,7 +188,6 @@ class _QuestaoEditarPageState extends State<QuestaoEditarPage> {
         ),
         TituloEditarWidget(alternativa.numeracao),
         EditorHtmlEnhanced(
-          height: 100,
           text: alternativa.descricao,
           onTextChanged: (text) {
             context.read<QuestaoEditarCubit>().changeAlternativa(alternativa.ordem, text);

--- a/lib/features/questao/presentation/widgets/editor_html/editor_html_enhanced.dart
+++ b/lib/features/questao/presentation/widgets/editor_html/editor_html_enhanced.dart
@@ -6,7 +6,7 @@ class EditorHtmlEnhanced extends StatefulWidget {
     super.key,
     required this.text,
     required this.onTextChanged,
-    this.height = 300,
+    this.height = 350,
   });
 
   final String text;


### PR DESCRIPTION

## Descrição

fix [AB#99087](https://dev.azure.com/amcomgov/c9b99f20-3b4d-464b-a2eb-69d1f704e9d3/_workitems/edit/99087)


## Tipo de Mudança

<!--- Coloque um `x` em todas as caixas que se aplicam: -->

- [ ] ✨ Novo recurso (alteração ininterrupta que adiciona funcionalidade)
- [X] 🛠️ Bug fix (mudança ininterrupta que corrige um problema)
- [ ] ❌ Breaking change (correção ou recurso que faria com que a funcionalidade existente fosse alterada)
- [ ] 🧹 Refatoração de código
- [ ] ✅ Alteração de configuração de compilação
- [ ] 📝 Documentação
- [ ] 🗑️ Chore (Tarefa) 
- [ ] 🔄 Sincronização de branch
